### PR TITLE
Add minimum size validation to Grid constructor and update tests

### DIFF
--- a/src/grid/grid.test.ts
+++ b/src/grid/grid.test.ts
@@ -26,6 +26,22 @@ Deno.test("Valid constructor params", async (t) => {
 });
 
 Deno.test("Invalid constructor params", async (t) => {
+  await t.step("should throw when width is below minimum", () => {
+    assertThrows(
+      () => new Grid({ x: 2, y: 5 }),
+      Error,
+      "Width must be at least 3",
+    );
+  });
+
+  await t.step("should throw when height is below minimum", () => {
+    assertThrows(
+      () => new Grid({ x: 5, y: 2 }),
+      Error,
+      "Height must be at least 3",
+    );
+  });
+
   await t.step("should throw when cell x coordinate is out of bounds", () => {
     const bottomRightCorner: Point = { x: 5, y: 5 };
     const liveCells: LiveCells = new Map();
@@ -357,7 +373,7 @@ Deno.test("Grid.place with Overwrite mode", async (t) => {
 
       const innerCells: LiveCells = new Map();
       innerCells.set(pointToCellKey({ x: 1, y: 0 }), true);
-      const inner = new Grid({ x: 2, y: 2 }, innerCells);
+      const inner = new Grid({ x: 3, y: 3 }, innerCells);
 
       outer.place({ inner });
 
@@ -395,7 +411,7 @@ Deno.test("Grid.place with Overwrite mode", async (t) => {
       const innerCells: LiveCells = new Map();
       innerCells.set(pointToCellKey({ x: 0, y: 0 }), true);
       innerCells.set(pointToCellKey({ x: 1, y: 0 }), true);
-      const inner = new Grid({ x: 2, y: 2 }, innerCells);
+      const inner = new Grid({ x: 3, y: 3 }, innerCells);
 
       outer.place({ inner, offset: { x: 5, y: 5 } });
 

--- a/src/grid/grid.ts
+++ b/src/grid/grid.ts
@@ -11,6 +11,8 @@ import {
   ALIVE_CHAR,
   CELL_CHAR_TO_BOOL,
   DEAD_CHAR,
+  MIN_WORLD_HEIGHT,
+  MIN_WORLD_WIDTH,
   NEWLINE_CHAR,
   PLACEMENT_MODES,
   SEED_PATTERN,
@@ -23,6 +25,14 @@ export class Grid implements IGrid {
   #liveCells: LiveCells;
 
   constructor(bottomRightCorner: Point, liveCells?: LiveCells) {
+    if (bottomRightCorner.x < MIN_WORLD_WIDTH) {
+      throw new Error(`Width must be at least ${MIN_WORLD_WIDTH}`);
+    }
+
+    if (bottomRightCorner.y < MIN_WORLD_HEIGHT) {
+      throw new Error(`Height must be at least ${MIN_WORLD_HEIGHT}`);
+    }
+
     this.#bottomRightCorner = bottomRightCorner;
 
     if (liveCells) {
@@ -50,7 +60,7 @@ export class Grid implements IGrid {
     return this.#bottomRightCorner;
   }
 
-  get liveCells(): {key: Point, value: boolean}[] {
+  get liveCells(): { key: Point; value: boolean }[] {
     return Array.from(this.#liveCells, ([cellKey, value]) => ({
       key: cellKeyToPoint(cellKey),
       value,


### PR DESCRIPTION
Grid constructor now throws when width or height is below the minimum (3), consistent with Engine and Grid.fromString. Tests updated to cover the new validation and to use valid 3x3 inner grids in placement tests.