### PR TITLE
Document git workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,4 @@ CI (`.github/workflows/publish.yml`) auto-publishes to JSR on push to `main` usi
 
 - Always merge PRs with `gh pr merge <number> --squash`
 - After a squash merge, all branch commits are folded into one commit on main. Do not rebase the working branch onto main — reset directly instead: `git reset --hard origin/main`
+- After resetting a working branch, the remote will be out of sync — force push with `git push --force-with-lease`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,10 @@ When adding features, add tests in the colocated `.test.ts` file. Validate with 
 ## Publishing
 
 CI (`.github/workflows/publish.yml`) auto-publishes to JSR on push to `main` using `npx jsr publish`. Version is set in `deno.json`.
+
+## Git / GitHub
+
+`origin/main` is protected: linear history only, **squash merge only** (no regular merge commits).
+
+- Always merge PRs with `gh pr merge <number> --squash`
+- After a squash merge, all branch commits are folded into one commit on main. Do not rebase the working branch onto main — reset directly instead: `git reset --hard origin/main`


### PR DESCRIPTION
## Summary

- Documents the squash-only merge policy for `origin/main`
- Notes the correct post-merge reset approach instead of rebasing
- Notes the required force push after resetting a working branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)