### PR TITLE
Add test:agent script for automated test runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@ Conway's Game of Life simulation engine published as a JSR package (`@hidarikani
 ## Commands
 
 ```bash
-# Run tests (watch mode)
-deno task test:watch
+# Run tests once (for agents — run this after every code change)
+deno task test:ci
 
-# Run tests once
-deno test --allow-read
+# Run tests (watch mode, for human developers)
+deno task test:watch
 
 # Publish (CI handles this automatically on push to main)
 npx jsr publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,6 @@ Conway's Game of Life simulation engine published as a JSR package (`@hidarikani
 # Run tests once (for agents — run this after every code change)
 deno task test:agent
 
-# Run tests (watch mode, for human developers)
-deno task test:watch
-
 # Publish (CI handles this automatically on push to main)
 npx jsr publish
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Conway's Game of Life simulation engine published as a JSR package (`@hidarikani
 
 ```bash
 # Run tests once (for agents — run this after every code change)
-deno task test:ci
+deno task test:agent
 
 # Run tests (watch mode, for human developers)
 deno task test:watch

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "exports": "./mod.ts",
   "tasks": {
-    "test:watch": "deno test --watch"
+    "test:watch": "deno test --watch",
+    "test:ci": "deno test"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1"

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
   "exports": "./mod.ts",
   "tasks": {
     "test:watch": "deno test --watch",
-    "test:ci": "deno test"
+    "test:agent": "deno test"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1"


### PR DESCRIPTION
## Summary

- Adds `test:agent` task to `deno.json` — a non-watch test run intended for agents to verify tests after code changes
- Documents `test:agent` in `CLAUDE.md` as the expected command to run after every code change
- Removes `test:watch` from `CLAUDE.md` (human-facing, not relevant to agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)