### PR TITLE
Consolidate test instructions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,6 @@ Conway's Game of Life simulation engine published as a JSR package (`@hidarikani
 ## Commands
 
 ```bash
-# Run tests once (for agents — run this after every code change)
-deno task test:agent
-
 # Publish (CI handles this automatically on push to main)
 npx jsr publish
 ```
@@ -53,8 +50,10 @@ patterns.yaml     # Named Game of Life patterns (e.g., Blinker)
 
 Uses Deno's built-in test runner with `@std/assert`. Tests are hierarchical — `Deno.test()` with nested `t.step()`.
 
+After every code change, run tests with:
+
 ```bash
-deno task test:watch
+deno task test:agent
 ```
 
 Test files live alongside source: `engine.test.ts`, `grid.test.ts`, `geometry.test.ts`, `seed.test.ts`.


### PR DESCRIPTION
## Summary

- Removes `test:agent` from `## Commands` (it was duplicated)
- Moves the instruction into `## Testing` with a clear directive to run it after every code change
- Removes the stale `test:watch` reference from `## Testing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)