### PR TITLE
Add Engine API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ console.log(engine.toString());
 // . . . . .
 ```
 
+A runnable version of this example is available in [`demo.ts`](demo.ts).
+
 ### Engine
 
 See [src/engine/README.md](src/engine/README.md) for full `Engine` API documentation

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ console.log(engine.toString());
 // . . . . .
 ```
 
-A runnable version of this example is available in [`demo.ts`](demo.ts).
+A runnable version of this example is available in [`demo.ts`](demo.ts):
+
+```sh
+deno run demo.ts
+```
 
 ### Engine
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ behavior of border cells depends on `GridMode`.
   For example when trying to access cell at `{ x: 9, y: 5}` it shall be
   translated to `{ x: 0, y: 0 }`.
 
+## Engine
+
+See [src/engine/README.md](src/engine/README.md) for full `Engine` API documentation
+and usage examples.
+
 ## Grid
 
 See [src/grid/README.md](src/grid/README.md) for full `Grid` API documentation

--- a/README.md
+++ b/README.md
@@ -2,39 +2,53 @@
 
 ## Usage
 
-Install
+Install:
 
 ```sh
 deno add jsr:@hidarikani/game-of-life-engine
 ```
 
-Import, create an `Engine` instance and compute one generation.
+Create a `Grid` from a seed string, pass it to `Engine`, then call `evolveGrid()`
+to step the simulation forward.
 
 ```ts
-import {
-  GridMode,
-  Rectangle,
-  Engine,
-  EngineOptions,
-} from "@hidarikani/game-of-life-engine";
+import { Engine, Grid } from "@hidarikani/game-of-life-engine";
+import type { GridSize } from "@hidarikani/game-of-life-engine";
 
-const gridSize: Rectangle = { w: 5, h: 5 };
-const mode: GridMode = GRID_MODES.TOROIDAL;
-const seed = `
-      . . . . .
-      . . # . .
-      . . # . .
-      . . # . .
-      . . . . .
-    `;
-const engineOptions: EngineOptions = { gridSize, mode, seed };
+const gridSize: GridSize = { w: 5, h: 5 };
 
-const engineFoo = new Engine(engineOptions);
-const engineBar = new Engine({ gridSize });
+// A vertical blinker
+const firstGeneration = Grid.fromString({
+  gridSize,
+  seed: `
+    . . . . .
+    . . # . .
+    . . # . .
+    . . # . .
+    . . . . .
+  `,
+});
 
-engineFoo.evolveGrid();
-const actual = engineFoo.toString();
+const engine = new Engine({ firstGeneration });
+
+engine.evolveGrid();
+console.log(engine.toString());
+// . . . . .
+// . . . . .
+// . # # # .
+// . . . . .
+// . . . . .
 ```
+
+### Engine
+
+See [src/engine/README.md](src/engine/README.md) for full `Engine` API documentation
+and usage examples.
+
+### Grid
+
+See [src/grid/README.md](src/grid/README.md) for full `Grid` API documentation
+and usage examples.
 
 ## Coordinates
 
@@ -80,16 +94,6 @@ behavior of border cells depends on `GridMode`.
   interactions—your glider can collide with its own past if the grid is small.
   For example when trying to access cell at `{ x: 9, y: 5}` it shall be
   translated to `{ x: 0, y: 0 }`.
-
-## Engine
-
-See [src/engine/README.md](src/engine/README.md) for full `Engine` API documentation
-and usage examples.
-
-## Grid
-
-See [src/grid/README.md](src/grid/README.md) for full `Grid` API documentation
-and usage examples.
 
 ## Development
 

--- a/demo.ts
+++ b/demo.ts
@@ -1,0 +1,26 @@
+import { Engine, Grid } from "./mod.ts";
+import type { GridSize } from "./mod.ts";
+
+const gridSize: GridSize = { w: 5, h: 5 };
+
+// A vertical blinker
+const firstGeneration = Grid.fromString({
+  gridSize,
+  seed: `
+    . . . . .
+    . . # . .
+    . . # . .
+    . . # . .
+    . . . . .
+  `,
+});
+
+const engine = new Engine({ firstGeneration });
+
+engine.evolveGrid();
+console.log(engine.toString());
+// . . . . .
+// . . . . .
+// . # # # .
+// . . . . .
+// . . . . .

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,7 @@
 export { Grid } from "./src/grid/grid.ts"
 export { Engine } from "./src/engine/engine.ts";
+export { GRID_MODES, PLACEMENT_MODES } from "./src/constants.ts";
+export { pointToCellKey } from "./src/seed/seed.ts";
 export type {
   EngineOptions,
   GridMode,
@@ -8,6 +10,7 @@ export type {
   GridSize,
   IEngine,
   IGrid,
+  LiveCells,
   PlacementMode,
   Point,
 } from "./src/types.ts";

--- a/src/engine/README.md
+++ b/src/engine/README.md
@@ -1,0 +1,117 @@
+# Engine
+
+`Engine` is the main entry point for running a Game of Life simulation. It owns
+the grid state and advances it one generation at a time.
+
+## Instantiation
+
+`Engine` does not accept a seed string directly. You first create a `Grid` (see
+[`src/grid/README.md`](../grid/README.md)), then pass it as `firstGeneration`.
+
+```ts
+import { Engine, Grid, GRID_MODES } from "@hidarikani/game-of-life-engine";
+import type { GridSize } from "@hidarikani/game-of-life-engine";
+
+const gridSize: GridSize = { w: 5, h: 5 };
+
+const firstGeneration = Grid.fromString({
+  gridSize,
+  seed: `
+    . . . . .
+    . . # . .
+    . . # . .
+    . . # . .
+    . . . . .
+  `,
+});
+
+const engine = new Engine({ firstGeneration });
+```
+
+### Grid mode
+
+The grid mode (`Finite` or `Toroidal`) is set on the `Grid`, not the `Engine`.
+The engine inherits it from `firstGeneration`.
+
+```ts
+const firstGeneration = Grid.fromString({
+  gridSize,
+  seed: `...`,
+  mode: GRID_MODES.TOROIDAL,
+});
+
+const engine = new Engine({ firstGeneration });
+console.log(engine.mode); // GRID_MODES.TOROIDAL
+```
+
+### Generation history
+
+`Engine` keeps a rolling window of past generations in memory. The default is 3.
+You can configure it with `maxHistory` — passing a value less than 1 throws an error.
+
+```ts
+const engine = new Engine({ firstGeneration, maxHistory: 10 });
+```
+
+## Running a simulation
+
+Call `evolveGrid()` to advance one generation. The result is stored internally
+and accessible via `presentGeneration` or `toString()`.
+
+```ts
+// Blinker: vertical bar oscillates to horizontal bar after one step
+const firstGeneration = Grid.fromString({
+  gridSize: { w: 5, h: 5 },
+  seed: `
+    . . . . .
+    . . # . .
+    . . # . .
+    . . # . .
+    . . . . .
+  `,
+});
+
+const engine = new Engine({ firstGeneration });
+
+engine.evolveGrid();
+
+console.log(engine.toString());
+// . . . . .
+// . . . . .
+// . # # # .
+// . . . . .
+// . . . . .
+```
+
+To run multiple generations in a loop:
+
+```ts
+for (let i = 0; i < 10; i++) {
+  engine.evolveGrid();
+  console.log(`Generation ${i + 1}:`);
+  console.log(engine.toString());
+}
+```
+
+## Inspecting state
+
+```ts
+engine.gridSize           // { w: 5, h: 5 }
+engine.mode               // GRID_MODES.FINITE or GRID_MODES.TOROIDAL
+engine.presentGeneration  // the current Grid
+engine.firstGeneration    // the initial Grid
+engine.historyLength      // number of generations currently stored
+engine.maxHistory         // rolling window size
+
+engine.readCell({ x: 2, y: 2 })  // true if cell is alive, false if dead
+```
+
+## Checking a single cell's next state
+
+`evolveCell(point)` applies the Game of Life rules to one cell and returns its
+next state, without mutating any grid state. Useful for inspection or custom
+rendering logic.
+
+```ts
+const willBeAlive = engine.evolveCell({ x: 2, y: 2 }); // boolean
+```


### PR DESCRIPTION
## Summary

- Adds `src/engine/README.md` documenting how to instantiate `Engine` and run a simulation
- Covers: constructor params, grid mode, `maxHistory`, `evolveGrid()`, state inspection, and `evolveCell()`
- Examples reverse-engineered from `engine.test.ts`; error messages omitted as they are subject to change

🤖 Generated with [Claude Code](https://claude.com/claude-code)