### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidarikani/game-of-life-engine",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "tasks": {


### PR DESCRIPTION
## Summary

- Bumps package version from `0.3.0` to `0.4.0`
- Reflects new public exports added in the previous release (`GRID_MODES`, `PLACEMENT_MODES`, `LiveCells`, `pointToCellKey`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)